### PR TITLE
Bugfix/apple error messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ App Store (validates `receipt` using optional `shared-secret` against iTunes ser
     except InAppPyValidationError as ex:
         # handle validation error
         response_from_apple = ex.raw_response  # contains actual response from AppStore service.
+        error_message = ex.error_message       # contains error message translated from error code
         pass
 
 App Store Response (`validation_result` / `raw_response`) Sample:

--- a/inapppy/errors.py
+++ b/inapppy/errors.py
@@ -2,7 +2,8 @@
 class InAppPyValidationError(Exception):
     """ Base class for all validation errors """
     raw_response = None
+    error_message = None
 
-    def __init__(self, raw_response=None):
+    def __init__(self, error_message=None):
         super(InAppPyValidationError, self).__init__()
-        self.raw_response = raw_response
+        self.error_message = error_message


### PR DESCRIPTION
Update InAppPyValidationError to save human readable message as `error_message` param and optionally set `raw_response`.