### PR TITLE
Add support for exclude-old-transactions flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,14 +45,19 @@ App Store (validates `receipt` using optional `shared-secret` against iTunes ser
 
 
     bundle_id = 'com.yourcompany.yourapp'
-    validator = AppStoreValidator(bundle_id)
+    auto_retry_wrong_env_request=False # if True, automatically query sandbox endpoint if
+                                       # validation fails on production endpoint
+    validator = AppStoreValidator(bundle_id, auto_retry_wrong_env_request=auto_retry_wrong_env_request)
 
     try:
-        validation_result = validator.validate('receipt', 'optional-shared-secret')
+        exclude_old_transactions=False # if True, include only the latest renewal transaction
+        validation_result = validator.validate('receipt', 'optional-shared-secret', exclude_old_transactions=exclude_old_transactions)
     except InAppPyValidationError as ex:
         # handle validation error
         response_from_apple = ex.raw_response  # contains actual response from AppStore service.
         pass
+
+
 
 App Store Response (`validation_result` / `raw_response`) Sample:
 -----------------------------------------------------------------

--- a/inapppy/appstore.py
+++ b/inapppy/appstore.py
@@ -55,7 +55,7 @@ class AppStoreValidator(object):
         except (ValueError, RequestException):
             raise InAppPyValidationError('HTTP error')
 
-    def validate(self, receipt, shared_secret=None):
+    def validate(self, receipt, shared_secret=None, exclude_old_transactions=False):
         """ Validates receipt against apple services.
 
         :param receipt: receipt
@@ -66,6 +66,9 @@ class AppStoreValidator(object):
 
         if shared_secret:
             receipt_json['password'] = shared_secret
+
+        if exclude_old_transactions:
+            receipt_json['exclude-old-transcations'] = True
 
         # Do a request.
         api_response = self.post_json(receipt_json)

--- a/inapppy/appstore.py
+++ b/inapppy/appstore.py
@@ -60,6 +60,7 @@ class AppStoreValidator(object):
 
         :param receipt: receipt
         :param shared_secret: optional shared secret.
+        :param exclude_old_transactions: optional to include only the latest renewal transaction
         :return: validation result or exception.
         """
         receipt_json = {'receipt-data': receipt}


### PR DESCRIPTION
When adding the exclude-old-transaction flag, Apple's validation servers should only include the latest renewal transaction for any subscriptions (valid for iOS 7 style subscriptions only). 

Closes #3 