### PR TITLE
Googleplay verification added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,5 @@ LICENSE
 Pipfile
 Pipfile.lock
 README.rst
-inapppy/__init__.py
-inapppy/errors.py
-inapppy/googleplay.py
 setup.py
-tests/
 tox.ini

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,38 @@ Google Play (validates `receipt` against provided `signature` using RSA):
         # handle validation error
         pass
 
+Google Play verification:
+-------------------------------------------------------------------------
+.. code:: python
+
+    from inapppy import GooglePlayVerifier, errors
+
+
+    def google_validator(in_receipt):
+        """
+        Accepts receipt, validates in Google.
+        """
+        purchase_token = receipt['purchaseToken']
+        product_sku = receipt['productId']
+        verifier = GooglePlayValidator(
+            GOOGLE_BUNDLE_ID,
+            GOOGLE_SERVICE_ACCOUNT_KEY_FILE,
+        )
+        response = {'valid': False, 'transactions': []}
+        try:
+            result = verifier.verify(
+                purchase_token,
+                product_sku
+            )
+            response['valid'] = True
+            response['transactions'].append(
+                (result['orderId'], product_sku)
+            )
+        except errors.GoogleError as exc:
+            logging.error('Purchase validation failed {}'.format(exc))
+        return response
+
+
 App Store (validates `receipt` using optional `shared-secret` against iTunes service):
 --------------------------------------------------------------------------------------
 .. code:: python

--- a/inapppy/appstore.py
+++ b/inapppy/appstore.py
@@ -26,7 +26,7 @@ class AppStoreValidator(object):
     url = None
     auto_retry_wrong_env_request = False
 
-    def __init__(self, bundle_id, sandbox=False, auto_retry_wrong_env_request=False):
+    def __init__(self, bundle_id, sandbox=False, auto_retry_wrong_env_request=False, http_timeout=None):
         """ Constructor for AppStoreValidator
 
         :param bundle_id: apple bundle id
@@ -35,6 +35,7 @@ class AppStoreValidator(object):
         """
         self.bundle_id = bundle_id
         self.sandbox = sandbox
+        self.http_timeout = http_timeout
 
         if not self.bundle_id:
             raise InAppPyValidationError('`bundle_id` cannot be empty')
@@ -51,7 +52,7 @@ class AppStoreValidator(object):
         self._change_url_by_sandbox()
 
         try:
-            return requests.post(self.url, json=request_json).json()
+            return requests.post(self.url, json=request_json, timeout=self.http_timeout).json()
         except (ValueError, RequestException):
             raise InAppPyValidationError('HTTP error')
 

--- a/inapppy/errors.py
+++ b/inapppy/errors.py
@@ -9,11 +9,3 @@ class InAppPyValidationError(Exception):
 
 class GoogleError(InAppPyValidationError):
     pass
-
-
-class GoogleCanceled(GoogleError):
-    pass
-
-
-class GoogleExpired(GoogleError):
-    pass

--- a/inapppy/errors.py
+++ b/inapppy/errors.py
@@ -1,8 +1,19 @@
-
 class InAppPyValidationError(Exception):
     """ Base class for all validation errors """
     raw_response = None
 
-    def __init__(self, raw_response=None):
-        super(InAppPyValidationError, self).__init__()
-        self.raw_response = raw_response
+    def __init__(self, *args, **kwargs):
+        self.raw_response = kwargs.pop('raw_response', None)
+        super().__init__(*args, **kwargs)
+
+
+class GoogleError(InAppPyValidationError):
+    pass
+
+
+class GoogleCanceled(GoogleError):
+    pass
+
+
+class GoogleExpired(GoogleError):
+    pass

--- a/inapppy/googleplay.py
+++ b/inapppy/googleplay.py
@@ -85,17 +85,20 @@ class GooglePlayVerifier:
         return http
 
 
-    def verify(self, purchase_token, product_sku):
+    def verify(self, purchase_token, product_sku, is_subscription=False):
         service = build("androidpublisher", "v3", http=self.http)
-        result = service.purchases().subscriptions().get(
-            packageName=self.bundle_id,
-            subscriptionId=product_sku,
-            token=purchase_token
-        ).execute(http=self.http)
-        cancel_reason = int(result.get('cancelReason', 0))
-        if cancel_reason != 0:
-            raise GoogleCanceled(result)
-        ms_timestamp = result.get('expiryTimeMillis', 0)
-        if _ms_timestamp_expired(ms_timestamp):
-            raise GoogleExpired(result)
+        if is_subscription:
+            result = service.purchases().subscriptions().get(
+                packageName=self.bundle_id,
+                subscriptionId=product_sku,
+                token=purchase_token
+            ).execute(http=self.http)
+            cancel_reason = int(result.get('cancelReason', 0))
+            if cancel_reason != 0:
+                raise GoogleCanceled(result)
+            ms_timestamp = result.get('expiryTimeMillis', 0)
+            if _ms_timestamp_expired(ms_timestamp):
+                raise GoogleExpired(result)
+        else:
+            raise NotImplementedError()
         return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+rsa==4.0
+requests==2.19
+httplib2==0.11.3
+google-api-python-client==1.7.4
+# oauth2client 4.x.x and above don't have a crucial component for our purposes
+oauth2client==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup
 
 setup(
     name='inapppy',
-    version='0.6',
+    version='0.7',
     packages=['inapppy'],
-    install_requires=['rsa', 'requests'],
+    install_requires=['rsa', 'requests', 'google-api-python-client'],
     description="In-app purchase validation library for Apple AppStore and GooglePlay.",
     keywords='in-app store purchase googleplay appstore validation',
     author='Lukas Šalkauskas',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='inapppy',
     version='0.7',
     packages=['inapppy'],
-    install_requires=['rsa', 'requests', 'google-api-python-client'],
+    install_requires=['rsa', 'requests', 'google-api-python-client', 'oauth2client==3.0.0'],
     description="In-app purchase validation library for Apple AppStore and GooglePlay.",
     keywords='in-app store purchase googleplay appstore validation',
     author='Lukas Šalkauskas',

--- a/tests/test_appstore.py
+++ b/tests/test_appstore.py
@@ -1,8 +1,7 @@
 import pytest
 from unittest.mock import patch
 
-from inapppy.appstore import AppStoreValidator
-from inapppy.errors import InAppPyValidationError
+from inapppy import InAppPyValidationError, AppStoreValidator
 
 
 def test_appstore_validator_initiation_raises_if_no_bundle_id():

--- a/tests/test_google_verifier.py
+++ b/tests/test_google_verifier.py
@@ -1,0 +1,36 @@
+import datetime
+
+import pytest
+from unittest.mock import patch
+
+from inapppy import googleplay, errors
+
+
+def test_google_verify_non_subscription():
+    with patch.object(googleplay, 'build', return_value=None):
+        with patch.object(googleplay.GooglePlayVerifier, '_authorize', return_value=None):
+            verifier = googleplay.GooglePlayVerifier('test-bundle-id', 'private_key_path', 30)
+            with patch.object(verifier, 'get_subscriptions', return_value={}):
+                with pytest.raises(NotImplementedError):
+                    verifier.verify('test-token', 'test-product')
+
+
+def test_google_verify_subscription():
+    with patch.object(googleplay, 'build', return_value=None):
+        with patch.object(googleplay.GooglePlayVerifier, '_authorize', return_value=None):
+            verifier = googleplay.GooglePlayVerifier('test-bundle-id', 'private_key_path', 30)
+
+            # expired
+            with patch.object(verifier, 'get_subscriptions', return_value={'expiryTimeMillis': 666}):
+                with pytest.raises(errors.GoogleError):
+                    verifier.verify('test-token', 'test-product', is_subscription=True)
+
+            # canceled
+            with patch.object(verifier, 'get_subscriptions', return_value={'cancelReason': 666}):
+                with pytest.raises(errors.GoogleError):
+                    verifier.verify('test-token', 'test-product', is_subscription=True)
+
+            # norm
+            now = datetime.datetime.utcnow().timestamp()
+            with patch.object(verifier, 'get_subscriptions', return_value={'expiryTimeMillis': now * 1000 + 10**10}):
+                verifier.verify('test-token', 'test-product', is_subscription=True)

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,4 @@ envlist = py{27,35}
 commands = py.test -v
 deps =
     pytest
+    -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}
+envlist = py{35}
 
 [testenv]
 commands = py.test -v


### PR DESCRIPTION
Based on issue
https://github.com/dotpot/InAppPy/issues/1

Made a class that verifies receipt in google play.

Patched Apple validator to set timeout for http requests (default 60 seconds is sometimes too much).

Based on issue
https://github.com/dotpot/InAppPy/issues/2

Modified initializer of Exception base class to accept error message *and* raw_response.

Pls, consider taking a look.