### PR TITLE
Fixed GooglePlayValidator import in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Google Play verification:
 -------------------------------------------------------------------------
 .. code:: python
 
-    from inapppy import GooglePlayVerifier, errors
+    from inapppy import GooglePlayValidator, errors
 
 
     def google_validator(in_receipt):


### PR DESCRIPTION
This PR corrects the class used in the README to use GooglePlayVerifier instead of GooglePlayValidator.

This also exposes the GooglePlayVerifier class to be importable.