### PR TITLE
GooglePlayVerifier fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Google Play verification:
         """
         purchase_token = receipt['purchaseToken']
         product_sku = receipt['productId']
-        verifier = GooglePlayValidator(
+        verifier = GooglePlayVerifier(
             GOOGLE_BUNDLE_ID,
             GOOGLE_SERVICE_ACCOUNT_KEY_FILE,
         )

--- a/inapppy/__init__.py
+++ b/inapppy/__init__.py
@@ -1,3 +1,3 @@
 from .appstore import AppStoreValidator
-from .googleplay import GooglePlayValidator
+from .googleplay import GooglePlayValidator, GooglePlayVerifier
 from .errors import InAppPyValidationError

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 from setuptools import setup
 
 


### PR DESCRIPTION
This PR corrects the class used in the README to use GooglePlayVerifier instead of GooglePlayValidator.

This also exposes the GooglePlayVerifier class to be importable.