### PR TITLE
cast ms_timestamp to int. Fix Errors

### DIFF
--- a/inapppy/errors.py
+++ b/inapppy/errors.py
@@ -1,11 +1,12 @@
 class InAppPyValidationError(Exception):
     """ Base class for all validation errors """
-    raw_response = None
-
     def __init__(self, *args, **kwargs):
-        self.raw_response = kwargs.pop('raw_response', None)
         super().__init__(*args, **kwargs)
 
 
 class GoogleError(InAppPyValidationError):
-    pass
+    raw_response = None
+
+    def __init__(self, message, raw_response, *args, **kwargs):
+        self.raw_response = raw_response
+        super().__init__(message, raw_response, *args, **kwargs)

--- a/inapppy/googleplay.py
+++ b/inapppy/googleplay.py
@@ -74,9 +74,9 @@ class GooglePlayVerifier(object):
         self.http = self._authorize()
 
     @staticmethod
-    def _ms_timestamp_expired(ms_timestamp: int) -> bool:
+    def _ms_timestamp_expired(ms_timestamp: str) -> bool:
         now = datetime.datetime.utcnow()
-        dt = datetime.datetime.fromtimestamp(ms_timestamp / 1000)
+        dt = datetime.datetime.fromtimestamp(int(ms_timestamp) / 1000)
         return dt < now
 
     def _authorize(self):


### PR DESCRIPTION
I fixed two bugs.
1. cast ms_timestamp to int
2. propagate raw_response so we can catch and use it