### PR TITLE
Google: Added ability to authenticate with pre-parsed credential dict

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,39 @@ In-app purchase validation library for `Apple AppStore` and `GooglePlay` (`App S
         pass
 
 
+An additional example showing how to authenticate using dict credentials instead of loading from a file
+.. code:: python
+
+    import json
+    from inapppy import GooglePlayValidator, InAppPyValidationError
+
+
+    bundle_id = 'com.yourcompany.yourapp'
+    # Avoid hard-coding credential data in your code. This is just an example. 
+    api_credentials = json.loads('{'
+                                 '   "type": "service_account",'
+                                 '   "project_id": "xxxxxxx",'
+                                 '   "private_key_id": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",'
+                                 '   "private_key": "-----BEGIN PRIVATE KEY-----\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXX==\n-----END PRIVATE KEY-----\n",'
+                                 '   "client_email": "XXXXXXXXX@XXXXXXXX.XXX",'
+                                 '   "client_id": "XXXXXXXXXXXXXXXXXX",'
+                                 '   "auth_uri": "https://accounts.google.com/o/oauth2/auth",'
+                                 '   "token_uri": "https://oauth2.googleapis.com/token",'
+                                 '   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",'
+                                 '   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/XXXXXXXXXXXXXXXXX.iam.gserviceaccount.com"'
+                                 ' }')
+    validator = GooglePlayValidator(bundle_id, api_credentials)
+
+    try:
+        # receipt means `androidData` in result of purchase
+        # signature means `signatureAndroid` in result of purchase
+        validation_result = validator.validate('receipt', 'signature')
+    except InAppPyValidationError:
+        # handle validation error
+        pass
+
+
+
 4. Google Play verification
 ===========================
 .. code:: python

--- a/inapppy/errors.py
+++ b/inapppy/errors.py
@@ -1,4 +1,8 @@
-class InAppPyValidationError(Exception):
+class InAppPyError(Exception):
+    pass
+
+
+class InAppPyValidationError(InAppPyError):
     """ Base class for all validation errors """
 
     raw_response = None

--- a/inapppy/errors.py
+++ b/inapppy/errors.py
@@ -1,4 +1,5 @@
 class InAppPyError(Exception):
+    """ Base class for all errors """
     pass
 
 

--- a/inapppy/googleplay.py
+++ b/inapppy/googleplay.py
@@ -100,15 +100,15 @@ class GoogleVerificationResult:
 class GooglePlayVerifier:
     DEFAULT_AUTH_SCOPE = "https://www.googleapis.com/auth/androidpublisher"
     
-    def __init__(self, bundle_id: str, private_key: Union[str, dict], http_timeout: int = 15) -> None:
+    def __init__(self, bundle_id: str, play_console_credentials: Union[str, dict], http_timeout: int = 15) -> None:
         """
         Arguments:
             bundle_id: str - Also known as Android app's package name.
-            private_key_path - Path to Google's Service Account private key.
+            play_console_credentials - Path or dict contents of Google's Service Credentials
             http_timeout: int - HTTP connection timeout.
         """
         self.bundle_id = bundle_id
-        self.private_key = private_key
+        self.play_console_credentials = play_console_credentials
         self.http_timeout = http_timeout
         self.http = self._authorize()
 
@@ -129,20 +129,21 @@ class GooglePlayVerifier:
         return datetime.datetime.utcfromtimestamp(ms_timestamp_value) < now
 
     @staticmethod
-    def _create_credentials(private_key: Union[str, dict], scope_str: str):
-        # If str, assume its a filepath
-        if isinstance(private_key, str):
-            if not os.path.exists(private_key):
-                raise InAppPyError(f"Google API private key file does not exist: {private_key}")
-            return ServiceAccountCredentials.from_json_keyfile_name(private_key, scope_str)
+    def _create_credentials(play_console_credentials: Union[str, dict], scope_str: str):
+        # If str, assume it's a filepath
+        if isinstance(play_console_credentials, str):
+            if not os.path.exists(play_console_credentials):
+                raise InAppPyError(f"Google play console credentials file does not exist: {play_console_credentials}")
+            return ServiceAccountCredentials.from_json_keyfile_name(play_console_credentials, scope_str)
         # If dict, assume parsed json
-        if isinstance(private_key, dict):
-            return ServiceAccountCredentials.from_json_keyfile_dict(private_key, scope_str)
-        raise InAppPyError(f"Unknown private key format: {repr(private_key)}, expected 'dict' or 'str' types")
+        if isinstance(play_console_credentials, dict):
+            return ServiceAccountCredentials.from_json_keyfile_dict(play_console_credentials, scope_str)
+        raise InAppPyError(f"Unknown play console credentials format: {repr(play_console_credentials)}, "
+                           "expected 'dict' or 'str' types")
 
     def _authorize(self):
         http = httplib2.Http(timeout=self.http_timeout)
-        credentials = self._create_credentials(self.private_key, self.DEFAULT_AUTH_SCOPE)
+        credentials = self._create_credentials(self.play_console_credentials, self.DEFAULT_AUTH_SCOPE)
         http = credentials.authorize(http)
         return http
 


### PR DESCRIPTION
Added the ability to specify google API credentials via dict

## Description
1. Added the ability to specify google API credentials via dict
2. Created a generic InAppPyError for raises that do not concern receipt validation or google-specific error
3. Moved hardcoded scope string to class-level const
4. PEP small formatting changes

## Related Issue
https://github.com/dotpot/InAppPy/issues/38

## Motivation and Context
I am operating a backend that has multiple instances communicating for multiple apps. I would like to store pre-parsed credentials in the memory and not handle or rely on local files. File management brings additional complications that do not suite cloud-based backends. I believe this modification makes the package more robust.

## How Has This Been Tested?
I ran the unit-tests
I tested it in an actual usecase

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
