### PR TITLE
requirements & version bump

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ requests = "*"
 google-api-python-client = "*"
 "oauth2client" = "*"
 aiohttp = "*"
+urllib3 = "*"
 
 [dev-packages]
 pytest-sugar = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,17 +12,17 @@ attrs==20.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2,
 cachetools==4.2.1; python_version ~= '3.5'
 certifi==2020.12.5
 chardet==4.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-google-api-core==1.26.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-google-api-python-client==2.0.2
+google-api-core==1.26.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+google-api-python-client==2.1.0
 google-auth-httplib2==0.1.0
-google-auth==1.27.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+google-auth==1.28.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 googleapis-common-protos==1.53.0; python_version >= '3.6'
-httplib2==0.19.0
+httplib2==0.19.1
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 multidict==5.1.0; python_version >= '3.6'
 oauth2client==4.1.3
 packaging==20.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-protobuf==3.15.5
+protobuf==3.15.8
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
@@ -32,5 +32,5 @@ rsa==4.7.2; python_version >= '3.6'
 six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 typing-extensions==3.7.4.3
 uritemplate==3.0.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-urllib3==1.26.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
+urllib3==1.26.4
 yarl==1.6.3; python_version >= '3.6'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def get_description():
 
 setup(
     name="inapppy",
-    version="2.5.1",
+    version="2.5.2",
     packages=["inapppy", "inapppy.asyncio"],
     install_requires=["aiohttp", "rsa", "requests", "google-api-python-client", "oauth2client"],
     description="In-app purchase validation library for Apple AppStore and GooglePlay.",


### PR DESCRIPTION
* Updated: some of the requirements, mainly because of the [CVE-2021-28363](https://github.com/advisories/GHSA-5phf-pp7p-vc2r) in urllib3.

