### PR TITLE
Remove README example that's not working

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,41 +56,6 @@ In-app purchase validation library for `Apple AppStore` and `GooglePlay` (`App S
         # handle validation error
         pass
 
-
-An additional example showing how to authenticate using dict credentials instead of loading from a file
-
-.. code:: python
-
-    import json
-    from inapppy import GooglePlayValidator, InAppPyValidationError
-
-
-    bundle_id = 'com.yourcompany.yourapp'
-    # Avoid hard-coding credential data in your code. This is just an example. 
-    api_credentials = json.loads('{'
-                                 '   "type": "service_account",'
-                                 '   "project_id": "xxxxxxx",'
-                                 '   "private_key_id": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",'
-                                 '   "private_key": "-----BEGIN PRIVATE KEY-----\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXX==\n-----END PRIVATE KEY-----\n",'
-                                 '   "client_email": "XXXXXXXXX@XXXXXXXX.XXX",'
-                                 '   "client_id": "XXXXXXXXXXXXXXXXXX",'
-                                 '   "auth_uri": "https://accounts.google.com/o/oauth2/auth",'
-                                 '   "token_uri": "https://oauth2.googleapis.com/token",'
-                                 '   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",'
-                                 '   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/XXXXXXXXXXXXXXXXX.iam.gserviceaccount.com"'
-                                 ' }')
-    validator = GooglePlayValidator(bundle_id, api_credentials)
-
-    try:
-        # receipt means `androidData` in result of purchase
-        # signature means `signatureAndroid` in result of purchase
-        validation_result = validator.validate('receipt', 'signature')
-    except InAppPyValidationError:
-        # handle validation error
-        pass
-
-
-
 4. Google Play verification
 ===========================
 .. code:: python


### PR DESCRIPTION
## Description
The currently provided example is not working, as `GooglePlayValidator` is not expecting a `dict`. This example seems for suitable for section 4, Google Play Verification.

## Related Issue
Related to #78, as people trying this example will receive an error.

## Motivation and Context
The example is misleading.

## How Has This Been Tested?
By inspecting the code and trying the example.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
